### PR TITLE
Add a server-friendly model download command to the README

### DIFF
--- a/Matrix-Game-3/README.md
+++ b/Matrix-Game-3/README.md
@@ -44,6 +44,10 @@ pip install -r requirements.txt
 pip install "huggingface_hub[cli]"
 huggingface-cli download Matrix-Game-3.0 --local-dir Matrix-Game-3.0
 ```
+If you are downloading the model on a server, you can also use:
+```bash
+hf download Skywork/Matrix-Game-3.0 --local-dir Matrix-Game-3.0
+```
 ### Inference
 Before running inference, you need to prepare:
 - Input image


### PR DESCRIPTION
## Summary

This PR adds an alternative model download command to the README for server environments.

When using the original download command, I encountered the following error:

```text

Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/utils/_http.py", line 402, in hf_raise_for_status
    response.raise_for_status()
  File "/opt/conda/lib/python3.11/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/api/models/Matrix-Game-3.0/revision/main

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/conda/bin/hf", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/cli/hf.py", line 59, in main
    service.run()
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/cli/download.py", line 136, in run
    print(self._download())  # Print path to downloaded files
          ^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/cli/download.py", line 169, in _download
    return snapshot_download(
           ^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/_snapshot_download.py", line 245, in snapshot_download
    raise api_call_error
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/_snapshot_download.py", line 165, in snapshot_download
    repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/hf_api.py", line 2867, in repo_info
    return method(
           ^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/hf_api.py", line 2661, in model_info
    hf_raise_for_status(r)
  File "/opt/conda/lib/python3.11/site-packages/huggingface_hub/utils/_http.py", line 452, in hf_raise_for_status
    raise _format(RepositoryNotFoundError, message, response) from e
huggingface_hub.errors.RepositoryNotFoundError: 401 Client Error. (Request ID: Root=1-69d49c6a-42b163a9254e9d456f87e64a;f477db61-2860-42cf-b964-b5c45e30c76d)

Repository Not Found for url: https://huggingface.co/api/models/Matrix-Game-3.0/revision/main.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated. For more details, see https://huggingface.co/docs/huggingface_hub/authentication
Invalid username or password.

```
On many servers, Hugging Face authentication is not configured by default. In this case, the following command can be used instead:

```bash

hf download Skywork/Matrix-Game-3.0 --local-dir Matrix-Game-3.0

```

This keeps the original instructions while adding a more practical option for server-side usage.