### PR TITLE
Fix Matrix-Game-2 VAE decoding

### DIFF
--- a/Matrix-Game-2/utils/wan_wrapper.py
+++ b/Matrix-Game-2/utils/wan_wrapper.py
@@ -58,7 +58,7 @@ class WanVAEWrapper(torch.nn.Module): # todo
             decode_function = self.model.decode
 
         output = []
-        for u in zs:
+        for u in latent:
             output.append(decode_function(u.unsqueeze(0), scale).float().clamp_(-1, 1).squeeze(0))
         output = torch.stack(output, dim=0)
         return output
@@ -206,4 +206,3 @@ class WanDiffusionWrapper(torch.nn.Module):
         We can gradually add more methods here if needed.
         """
         self.get_scheduler()
-


### PR DESCRIPTION
## Summary

- iterate over the `latent` batch passed to `WanVAEWrapper.decode_to_pixel`
- restore both regular and cached Matrix-Game-2 VAE decoding

## Root cause and impact

`decode_to_pixel` accepts a tensor named `latent`, but the decode loop referenced an undefined variable named `zs`. Both decode paths therefore raised `NameError` before any generated latent could be converted back to video pixels.

## Validation

- `python -m ruff check Matrix-Game-2/utils/wan_wrapper.py --select F821,F822,F823`
- RTX 5090 CUDA regression with a synthetic VAE covering:
  - regular decoding with a batch of two latents
  - cached decoding with a single latent
  - output shape, CUDA device, float32 conversion, and `[-1, 1]` clamping
  - the existing cached-decode batch-size assertion
