### PR TITLE
Fix Matrix-Game-3 pipeline exit handling

### DIFF
--- a/Matrix-Game-3/pipeline/inference_interactive_pipeline.py
+++ b/Matrix-Game-3/pipeline/inference_interactive_pipeline.py
@@ -803,7 +803,4 @@ class MatrixGame3Pipeline:
                 else:
                     video = None
 
-            if dist.is_initialized():
-                dist.barrier()
-                dist.destroy_process_group()
-            exit()
+            return video

--- a/Matrix-Game-3/pipeline/inference_pipeline.py
+++ b/Matrix-Game-3/pipeline/inference_pipeline.py
@@ -706,7 +706,4 @@ class MatrixGame3Pipeline:
             else:
                 video = None
 
-            if dist.is_initialized():
-                dist.barrier()
-                dist.destroy_process_group()
-            exit()
+            return video


### PR DESCRIPTION
## Summary

- return the generated video from both Matrix-Game-3 pipeline variants
- leave distributed-process-group cleanup to the top-level caller that initialized it
- allow `generate.py` to run its synchronization, cleanup, and final log statements

## Root cause and impact

Both `MatrixGame3Pipeline.generate` implementations called `exit()` after saving the output. This terminated the entire interpreter instead of returning control to the caller, so the final statements in `generate.py` were unreachable and the pipelines could not be embedded in another Python process. They also destroyed the process group internally even though `generate.py` already owns that lifecycle.

Closes #77.

## Validation

- `python -m compileall -q Matrix-Game-3/generate.py Matrix-Game-3/pipeline/inference_pipeline.py Matrix-Game-3/pipeline/inference_interactive_pipeline.py`
- `python -m ruff check Matrix-Game-3/generate.py Matrix-Game-3/pipeline/inference_pipeline.py Matrix-Game-3/pipeline/inference_interactive_pipeline.py --select F821,F822,F823`
- RTX 5090 CUDA regression with stubbed model components and zero generation iterations, confirming that both non-interactive and interactive `generate()` methods return normally instead of raising `SystemExit`
